### PR TITLE
Use registered trademark's symbol for Build Scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# sbt Build Scan™ quickstart
+# sbt Build Scan® quickstart
 
-This is an example project that you can use to experience the [Build Scan™ service of Gradle Enterprise][gradle.com].
+This is an example project that you can use to experience the [Build Scan® service of Gradle Enterprise][gradle.com].
 
 It is a small Scala project that has the [Gradle Enterprise sbt plugin][manual] already applied.
 
@@ -10,7 +10,7 @@ sbt is expected to be installed. Please, follow [installing sbt](https://www.sca
 
 ## Create a Build Scan™
 
-Follow these simple steps to create and publish a Build Scan™ on [scans.gradle.com][scans.gradle.com]:
+Follow these simple steps to create and publish a Build Scan® on [scans.gradle.com][scans.gradle.com]:
 
 1. Clone this project
 1. Run `sbt package`
@@ -20,19 +20,19 @@ The build should end with something similar to:
     Publishing build scan...
     https://gradle.com/s/ria2s2x5oaazq
 
-Follow the link shown at the end of the build to view your Build Scan™ on [scans.gradle.com][scans.gradle.com].
+Follow the link shown at the end of the build to view your Build Scan® on [scans.gradle.com][scans.gradle.com].
 
-## Experiment with Build Scans
+## Experiment with build scans
 
-Create different kinds of Build Scans by locally modifying this quickstart project. Here are some ideas:
+Create different kinds of build scans by locally modifying this quickstart project. Here are some ideas:
 
 - Edit `src/main/scala/example/Example.scala` to introduce compile errors
 
-Alternatively, enable one of your own sbt builds to produce Build Scans by following the [step-by-step instructions][scans.gradle.com].
+Alternatively, enable one of your own sbt builds to produce build scans by following the [step-by-step instructions][scans.gradle.com].
 
 ## Learn more
 
-Read the [Gradle Enterprise sbt plugin User Manual][manual] to learn more about the Build Scan™ service of Gradle Enterprise and the Gradle Enterprise sbt plugin.
+Read the [Gradle Enterprise sbt plugin User Manual][manual] to learn more about the Build Scan® service of Gradle Enterprise and the Gradle Enterprise sbt plugin.
 
 ## Need help?
 


### PR DESCRIPTION
Also changed occurrences of "Build Scans" to "build scans" to be consistend with how we write it elsewhere in the documentation.