### PR TITLE
Fix broken Develocity docs link (docs.develocity.ai)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Talk to us on the [Gradle forum][gradle-forum].
 The sbt Build Scan® quickstart project is open-source software released under the [Apache 2.0 License][apache-license].
 
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html
-[manual]: https://docs.gradle.com/develocity/sbt-plugin
+[manual]: https://docs.develocity.ai/sbt/current/
 [gradle.com]: https://www.gradle.com
 [terms-of-use]: https://gradle.com/help/legal-terms-of-use
 [scans.gradle.com]: https://scans.gradle.com


### PR DESCRIPTION
## Summary

The `[manual]` link in the README pointed at `https://docs.gradle.com/develocity/sbt-plugin`, which now returns **404** (it 301-redirects to `docs.develocity.ai/sbt-plugin`, a path that no longer exists under the new docs domain).

This updates it to the current canonical sbt plugin docs home:

```
https://docs.develocity.ai/sbt/current/   (200 OK)
```

Caught by the README link check in `gradle/dv-docs` ([run](https://github.com/gradle/dv-docs/actions/runs/28697995895)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)