### PR TITLE
Restrict Renovate sbt updates to the 1.x line

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>gradle/renovate-agent//presets/dv.json5"
+  ],
+  "packageRules": [
+    {
+      // The Develocity sbt plugin only supports sbt 1.x, so stay on the 1.x line.
+      "matchPackageNames": ["sbt/sbt"],
+      "allowedVersions": "<2.0.0"
+    }
   ]
 }


### PR DESCRIPTION
## What

Add a Renovate package rule that disallows sbt 2.x updates, keeping the sbt version on the 1.x line.

```json5
"packageRules": [
  {
    "matchPackageNames": ["sbt/sbt"],
    "allowedVersions": "<2.0.0"
  }
]
```

## Why

The Develocity sbt plugin only supports sbt 1.x. Without this constraint, Renovate would eventually open PRs bumping `sbt.version` in `project/build.properties` to 2.x, which is incompatible.

The existing preset (`gradle/renovate-agent//presets/dv.json5`) is untouched — the rule is purely additive. Patch/minor 1.x updates continue to flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)